### PR TITLE
feat: make weekly goals dynamic

### DIFF
--- a/frontend/app/(main)/dashboard/page.tsx
+++ b/frontend/app/(main)/dashboard/page.tsx
@@ -141,11 +141,13 @@ export default async function Dashboard({
   // Fetch user settings for weekly goal target
   const { data: userSettings } = await supabase
     .from("user_settings")
-    .select("weekly_goal")
+    .select("weekly_goal, strength_goal_days, cardio_goal_minutes")
     .eq("user_id", user.id)
     .single();
 
   const weeklyGoalTarget = userSettings?.weekly_goal || 4; // Default to 4 days
+  const strengthGoalTarget = userSettings?.strength_goal_days ?? 3;
+  const cardioGoalTarget = userSettings?.cardio_goal_minutes ?? 120;
 
   // Fetch user profile for ProfileSummaryCard
   const { data: profile } = await supabase
@@ -222,14 +224,14 @@ export default async function Dashboard({
     {
       label: "Strength",
       current: weeklyStrength,
-      target: 3,
+      target: strengthGoalTarget,
       unit: "days",
       color: "bg-blue-500"
     },
     {
       label: "Cardio",
       current: weeklyCardio,
-      target: 120,
+      target: cardioGoalTarget,
       unit: "min",
       color: "bg-purple-500"
     },

--- a/frontend/app/(main)/settings/fitness-preferences/page.tsx
+++ b/frontend/app/(main)/settings/fitness-preferences/page.tsx
@@ -48,6 +48,8 @@ export default function FitnessPreferencesPage() {
     const [energyUnit, setEnergyUnit] = useState<"calories" | "kilojoules">("calories");
     const [primaryFocus, setPrimaryFocus] = useState("general_fitness");
     const [weeklyGoal, setWeeklyGoal] = useState(4);
+    const [strengthGoalDays, setStrengthGoalDays] = useState(3);
+    const [cardioGoalMinutes, setCardioGoalMinutes] = useState(120);
     const [activityLevel, setActivityLevel] = useState("lightly_active");
 
     const supabase = createBrowserClient(
@@ -71,6 +73,8 @@ export default function FitnessPreferencesPage() {
             setEnergyUnit(settings.energy_unit);
             setPrimaryFocus(settings.primary_focus);
             setWeeklyGoal(settings.weekly_goal);
+            setStrengthGoalDays(settings.strength_goal_days ?? 3);
+            setCardioGoalMinutes(settings.cardio_goal_minutes ?? 120);
             setActivityLevel(settings.activity_level);
 
             setLoading(false);
@@ -92,6 +96,8 @@ export default function FitnessPreferencesPage() {
             energy_unit: energyUnit,
             primary_focus: primaryFocus,
             weekly_goal: weeklyGoal,
+            strength_goal_days: strengthGoalDays,
+            cardio_goal_minutes: cardioGoalMinutes,
             activity_level: activityLevel,
         });
 
@@ -286,7 +292,7 @@ export default function FitnessPreferencesPage() {
                                     </select>
                                 </div>
 
-                                {/* Weekly Workout Goal */}
+                                {/* Weekly Workout Goal (Generic) */}
                                 <div>
                                     <div className="flex justify-between items-center mb-2">
                                         <label className="text-sm text-[var(--muted-foreground)]">Weekly Workout Goal</label>
@@ -303,6 +309,47 @@ export default function FitnessPreferencesPage() {
                                     <div className="flex justify-between text-xs text-[var(--color-accent)] mt-1">
                                         <span>1 day</span>
                                         <span>7 days</span>
+                                    </div>
+                                </div>
+
+                                {/* Strength Goal */}
+                                <div>
+                                    <div className="flex justify-between items-center mb-2">
+                                        <label className="text-sm text-[var(--muted-foreground)]">Strength Goal (Days)</label>
+                                        <span className="text-sm text-[var(--color-accent)] font-medium">{strengthGoalDays} days</span>
+                                    </div>
+                                    <input
+                                        type="range"
+                                        min="0"
+                                        max="7"
+                                        value={strengthGoalDays}
+                                        onChange={(e) => setStrengthGoalDays(Number(e.target.value))}
+                                        className="w-full h-2 bg-[var(--muted)] rounded-full appearance-none cursor-pointer accent-[var(--color-accent)]"
+                                    />
+                                    <div className="flex justify-between text-xs text-[var(--muted-foreground)] mt-1">
+                                        <span>0</span>
+                                        <span>7</span>
+                                    </div>
+                                </div>
+
+                                {/* Cardio Goal */}
+                                <div>
+                                    <div className="flex justify-between items-center mb-2">
+                                        <label className="text-sm text-[var(--muted-foreground)]">Cardio Goal (Minutes)</label>
+                                        <span className="text-sm text-[var(--color-accent)] font-medium">{cardioGoalMinutes} min</span>
+                                    </div>
+                                    <input
+                                        type="range"
+                                        min="0"
+                                        max="300"
+                                        step="10"
+                                        value={cardioGoalMinutes}
+                                        onChange={(e) => setCardioGoalMinutes(Number(e.target.value))}
+                                        className="w-full h-2 bg-[var(--muted)] rounded-full appearance-none cursor-pointer accent-[var(--color-accent)]"
+                                    />
+                                    <div className="flex justify-between text-xs text-[var(--muted-foreground)] mt-1">
+                                        <span>0</span>
+                                        <span>300</span>
                                     </div>
                                 </div>
                             </div>

--- a/frontend/app/actions/settings.ts
+++ b/frontend/app/actions/settings.ts
@@ -11,6 +11,8 @@ export interface UserSettings {
     energy_unit: "calories" | "kilojoules";
     primary_focus: string;
     weekly_goal: number;
+    strength_goal_days: number;
+    cardio_goal_minutes: number;
     activity_level: string;
 
     // Notifications
@@ -42,6 +44,8 @@ const defaultSettings: UserSettings = {
     energy_unit: "calories",
     primary_focus: "general_fitness",
     weekly_goal: 4,
+    strength_goal_days: 3,
+    cardio_goal_minutes: 120,
     activity_level: "lightly_active",
     pause_all_notifications: false,
     daily_reminders: false,
@@ -114,12 +118,15 @@ export async function updateUserSettings(
 }
 
 // Update fitness preferences specifically
+// Update fitness preferences specifically
 export async function updateFitnessPreferences(data: {
     distance_unit: string;
     weight_unit: string;
     energy_unit: string;
     primary_focus: string;
     weekly_goal: number;
+    strength_goal_days: number;
+    cardio_goal_minutes: number;
     activity_level: string;
 }): Promise<{ success: boolean; error?: string }> {
     return updateUserSettings({
@@ -128,6 +135,8 @@ export async function updateFitnessPreferences(data: {
         energy_unit: data.energy_unit as "calories" | "kilojoules",
         primary_focus: data.primary_focus,
         weekly_goal: data.weekly_goal,
+        strength_goal_days: data.strength_goal_days,
+        cardio_goal_minutes: data.cardio_goal_minutes,
         activity_level: data.activity_level,
     });
 }

--- a/supabase/migrations/015_add_specific_goals.sql
+++ b/supabase/migrations/015_add_specific_goals.sql
@@ -1,0 +1,4 @@
+-- Add specific goal columns to user_settings table
+ALTER TABLE user_settings
+ADD COLUMN IF NOT EXISTS strength_goal_days integer DEFAULT 3,
+ADD COLUMN IF NOT EXISTS cardio_goal_minutes integer DEFAULT 120;


### PR DESCRIPTION
- Add strength_goal_days and cardio_goal_minutes to user_settings table
- Update Fitness Preferences page to allow editing these goals
- Update Dashboard to display dynamic goals from DB