### PR TITLE
fix: sync calorie calculations and add consumed/goal display

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/utils/bmr.ts
+++ b/frontend/utils/bmr.ts
@@ -1,13 +1,15 @@
 // frontend/utils/bmr.ts
 import { ActivityLevel, Gender } from "@/types/database";
 
-// Mifflin-St Jeor Equation
+// Mifflin-St Jeor Equation with Weight Goal Adjustments
 export function calculateDailyCalories(
   weight: number,
   height: number,
   age: number,
   gender: Gender,
-  activityLevel: ActivityLevel
+  activityLevel: ActivityLevel,
+  primaryFocus?: string,
+  weeklyGoalKg?: number
 ): number {
   // Base BMR Calculation
   let bmr = 10 * weight + 6.25 * height - 5 * age;
@@ -27,7 +29,21 @@ export function calculateDailyCalories(
     extra_active: 1.9,
   };
 
-  return Math.round(bmr * (multipliers[activityLevel] || 1.2));
+  const maintenance = Math.round(bmr * (multipliers[activityLevel] || 1.2));
+
+  // Weight goal adjustment (if provided)
+  // 0.5kg per week = ~500 kcal deficit/surplus per day (7700 kcal per kg / 7 days ≈ 1100, but we use 600 for safety)
+  if (primaryFocus && weeklyGoalKg !== undefined) {
+    const dailyAdjustment = Math.abs(weeklyGoalKg) * 600;
+
+    if (primaryFocus === "weight_loss") {
+      return Math.round(maintenance - dailyAdjustment);
+    } else if (primaryFocus === "weight_gain") {
+      return Math.round(maintenance + dailyAdjustment);
+    }
+  }
+
+  return maintenance;
 }
 
 export function calculateAge(dob: string): number {


### PR DESCRIPTION
- Use shared calculateDailyCalories from utils/bmr.ts for consistency
- Fix getTodayNutrition to use meal_logs table (not food_logs)
- Update column names: protein_g, carbs_g, fat_g
- Add consumed/goal format to Settings page sidebar (e.g., 1000/2300 kcal)
- Add primaryFocus and weeklyGoalKg params to BMR calculation